### PR TITLE
Fix multiple same-line comments breakage

### DIFF
--- a/__tests__/rules/sort-keys-fix.js
+++ b/__tests__/rules/sort-keys-fix.js
@@ -1073,14 +1073,14 @@ tester.run('sort-keys-fix', rule, test)
  */
 describe('Autofix tests', () => {
   const linter = new Linter()
-  linter.defineRule('sort-keys-fix', rule);
+  linter.defineRule('sort-keys-fix', rule)
 
   it('should fix nested unsorted keys', () => {
     const actual = linter.verifyAndFix('var obj = {a:1, c:{y:1, x:1}, b:1}', {
       rules: {
         'sort-keys-fix': 1,
       },
-    });
+    })
 
     expect(actual.output).toEqual('var obj = {a:1, b:1, c:{x:1, y:1}}')
   })

--- a/__tests__/rules/sort-keys-fix.js
+++ b/__tests__/rules/sort-keys-fix.js
@@ -1,4 +1,4 @@
-const { RuleTester } = require('eslint')
+const { RuleTester, Linter } = require('eslint')
 const rule = require('../../rules/sort-keys-fix')
 
 const test = {
@@ -1027,21 +1027,19 @@ const test = {
       output: 'var obj = {[a]: -1, a:1, b:3, c:2}',
     },
     {
-      code: 'var obj = {a:1, c:{y:1, x:1}, b:1}',
-      errors: [
-        "Expected object keys to be in ascending order. 'x' should be before 'y'.",
-        "Expected object keys to be in ascending order. 'b' should be before 'c'.",
-      ],
-      // tested on real file and this works
-      // why it doesnt sort nested fields in unit test?
-      output: 'var obj = {a:1, b:1, c:{x:1, y:1}}',
-    },
-    {
       code: 'var obj = {\n  a:1,\n  _:2, // comment\n  b:3\n}',
       errors: [
         "Expected object keys to be in ascending order. '_' should be before 'a'.",
       ],
       output: 'var obj = {\n  _:2, // comment\n  a:1,\n  b:3\n}',
+    },
+    // multiple end-of-line comments
+    {
+      code: 'var obj = {\n a:3, // commenta\n _:2, // comment_\n}',
+      errors: [
+        "Expected object keys to be in ascending order. '_' should be before 'a'.",
+      ],
+      output: 'var obj = {\n _:2, // comment_\n a:3, // commenta\n}',
     },
     {
       code: 'var obj = {\n  // comment\n  // comment 2\n  a:1,\n  _:2,\n  b:3\n}',
@@ -1064,3 +1062,26 @@ const test = {
 
 const tester = new RuleTester()
 tester.run('sort-keys-fix', rule, test)
+
+/**
+ * RuleTester has two limitations that apply to this rule:
+ * 1. It only applies a single pass of autofixing, whereas the CLI will run multiple passes.
+ * 2. It does not allow you to change the AST (which this rule is likely to do).
+ *
+ * Using the node Linter interface directly lets us test the result accurately compared to a what
+ * happens in reality.
+ */
+describe('Autofix tests', () => {
+  const linter = new Linter()
+  linter.defineRule('sort-keys-fix', rule);
+
+  it('should fix nested unsorted keys', () => {
+    const actual = linter.verifyAndFix('var obj = {a:1, c:{y:1, x:1}, b:1}', {
+      rules: {
+        'sort-keys-fix': 1,
+      },
+    });
+
+    expect(actual.output).toEqual('var obj = {a:1, b:1, c:{x:1, y:1}}')
+  })
+})

--- a/rules/sort-keys-fix.js
+++ b/rules/sort-keys-fix.js
@@ -207,16 +207,7 @@ const moveProperty = (thisNode, toNode, fixer, src) => {
     const toNext = findCommaSameLine(toNode, src) || toNode
     const txt = src.text.substring(b, e)
     fixes.push(fixer.insertTextAfter(toNext, txt))
-    // In case the last comment overwrite the next token, add new line
-    const after = src.getTokenAfter(toNext, { includeComments: true })
-    if (
-      toNext.loc.end.line === after.loc.start.line &&
-      commentsAfter[commentsAfter.length - 1].type === 'Line'
-    ) {
-      fixes.push(fixer.insertTextBefore(after, '\n'))
-    }
   }
-  //
   return fixes
 }
 const findTokenPrevLine = (node, src) => {


### PR DESCRIPTION
Thanks for your work on this plugin!

I was getting the error `AssertionError [ERR_ASSERTION]: Fix objects must not be overlapped in a report.` when running locally and found it was caused when there are multiple inline comments in an object:

```ts
const obj = {
  b: 1, // inline-comment-b
  a: 2, // inline-comment-a
}
```

Also figured out what was wrong with the nested test, see the inline comments in the test file.